### PR TITLE
Added link to upgrade helper

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -243,6 +243,8 @@ export async function runVersion({
   let changelogBody = `
 # Release v${releaseVersion}
 
+Upgrade Helper: [https://backstage.github.io/upgrade-helper/?to=${releaseVersion}](https://backstage.github.io/upgrade-helper/?to=${releaseVersion})
+
 ${changelogEntries
   .filter((x) => x)
   .sort(sortTheThings)


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

This adds a link to the upgrade helper in the release notes and closes https://github.com/backstage/backstage/issues/9090