### PR TITLE
fix: Link to intermediate changelog

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -265,7 +265,7 @@ ${changelogEntries
 
   await fs.writeFile(changelogPath, changelogBody);
 
-  const prBody = `See [${changelogPath}](https://github.com/backstage/backstage/blob/master/${changelogPath}) for more information.`;
+  const prBody = `See [${changelogPath}](https://github.com/backstage/backstage/blob/${versionBranch}/${changelogPath}) for more information.`;
 
   const finalPrTitle = `${prTitle}${!!preState ? ` (${preState.tag})` : ""}`;
 


### PR DESCRIPTION
Whenever the Backstage service user updates the Version Updates PR, the description has a message which is unusable.

I've tried clicking it before, as have colleagues of mine, just to be redirected to a 404. That's because the message links to an intermediate changelog which doesn't yet actually exist, and the message link is hardcoded to the `master` branch.

This updates the action to make this link use the intermediate branch name so that users can preview the version updates in the pending changelog before the actual release is cut.

<img width="1166" alt="image" src="https://github.com/backstage/changesets-action/assets/33203301/264a5996-9b33-41cc-9544-1b091078a859">

The link in the description codes to:
https://github.com/backstage/backstage/blob/master/docs/releases/v1.15.0-next.1-changelog.md

While it SHOULD be:

https://github.com/backstage/backstage/blob/changeset-release/master/docs/releases/v1.15.0-next.1-changelog.md
(which does work and let's me preview the next changelog)