### PR TITLE
chore(deps): upgrade @actions/core from 1.3.0 to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release": "node ./scripts/release.js"
   },
   "dependencies": {
-    "@actions/core": "^1.3.0",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.0",
     "@actions/github": "^4.0.0",
     "@babel/core": "^7.13.10",


### PR DESCRIPTION
Addresses this https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.